### PR TITLE
Add single-version-externally-managed argument

### DIFF
--- a/jwst_coronagraph_visibility/bld.bat
+++ b/jwst_coronagraph_visibility/bld.bat
@@ -1,1 +1,1 @@
-%PYTHON% setup.py install
+%PYTHON% setup.py install --single-version-externally-managed --record=root.txt

--- a/jwst_coronagraph_visibility/build.sh
+++ b/jwst_coronagraph_visibility/build.sh
@@ -1,1 +1,1 @@
-$PYTHON setup.py install
+$PYTHON setup.py install --single-version-externally-managed --record=root.txt


### PR DESCRIPTION
`.egg`s tend to cause problems down the line, so we've been disabling them whenever possible. I'll go ahead and merge the upstream PR after this gets merged.